### PR TITLE
Fix error of blank FilesMatch value in .htaccess upon activation (and documentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ After a specified limit of login attempts within a specified time, the IP addres
 
 ## Installation
 1. Install the plugin either via the WordPress.org plugin directory, or by uploading the files to your wp-content/plugin directory.
+1a. `AllowOverride` must include `Limit` for this to work. 
+	E.g.
+	```
+	# /etc/apache2/apache2.conf
+	<Directory /var/www>
+    Options FollowSymLinks
+    AllowOverride FileInfo Limit
+    # AllowOverride All # another option, but less secure
+	</Directory>
+	```
 2. Activate the plugin through the WordPress admin panel.
 3. Customize the settings on the settings page.
 4. Done!

--- a/brute-force-login-protection.php
+++ b/brute-force-login-protection.php
@@ -141,6 +141,7 @@ class BruteForceLoginProtection
     public function activate()
     {
         $this->setHtaccessPath();
+        $this->htaccess->setFilesMatch();        
         $this->htaccess->uncommentLines();
     }
 


### PR DESCRIPTION
On activation, the first write to .htaccess looks something like this: 

``` xml
# BEGIN Brute Force Login Protection
<FilesMatch "">
order deny,allow
</FilesMatch>
# END Brute Force Login Protection
```

When an IP is added to the blacklist, it writes something like this: 

``` xml
# BEGIN Brute Force Login Protection
<FilesMatch "">
order deny,allow
<FilesMatch ".*\.(php|html?|css|js|jpe?g|png|gif)$">
deny from 52.29.141.208
</FilesMatch>
# END Brute Force Login Protection

```

...which throws an Apache error: `<FilesMatch> was not closed.`

What seemed most erroneous was the blank value for FilesMatch on activation. When setFilesMatch() is called before the initial write on activation, the tags are identified and closed properly. Problem is solved. 

---

Also I added to the documentation that the AllowOverride setting in Apache must include `Limit`. This setting was not set in my WordPress set-up (one-click install on Digital Ocean) and I needed to hunt it down. I think it might help some. 
